### PR TITLE
RetentionFileChooser Fix

### DIFF
--- a/Editor/src/main/java/com/rspsi/util/RetentionFileChooser.java
+++ b/Editor/src/main/java/com/rspsi/util/RetentionFileChooser.java
@@ -72,7 +72,10 @@ public class RetentionFileChooser {
 	
 	public static File showOpenDialog(Window ownerWindow, String defaultLoc, FilterMode... filterModes) {
 		if(!defaultLoc.isEmpty()) {
-			getInstance(filterModes).setInitialDirectory(new File(defaultLoc).getParentFile());
+			File parentDir = new File(defaultLoc).getParentFile();
+			if (parentDir != null && parentDir.isDirectory()) {
+				getInstance(filterModes).setInitialDirectory(parentDir);
+			}
 		}
 		File chosenFile = getInstance(filterModes).showOpenDialog(ownerWindow);
 		if (chosenFile != null) {


### PR DESCRIPTION
`Exception in thread "JavaFX Application Thread" java.lang.IllegalArgumentException: Folder parameter must be a valid folder
	at javafx.graphics/com.sun.glass.ui.CommonDialogs.convertFolder(CommonDialogs.java:239)
	at javafx.graphics/com.sun.glass.ui.CommonDialogs.showFileChooser(CommonDialogs.java:191)
	at javafx.graphics/com.sun.javafx.tk.quantum.QuantumToolkit.showFileChooser(QuantumToolkit.java:1718)
	at javafx.graphics/javafx.stage.FileChooser.showDialog(FileChooser.java:419)`


Fixed this error that happened when the json was missing or the dir was missing and you could not open the file view